### PR TITLE
fix: restore npm install functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13876,7 +13876,7 @@
       }
     },
     "packages/fast-check-bigint": {
-      "version": "0.0.0-semantically-released",
+      "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
         "@ericcrosson/eslint-config": "2.0.1",
@@ -13910,7 +13910,7 @@
       }
     },
     "packages/fast-check-numbers": {
-      "version": "0.0.0-semantically-released",
+      "version": "1.1.1",
       "license": "ISC",
       "devDependencies": {
         "@ericcrosson/eslint-config": "2.0.1",
@@ -13944,7 +13944,7 @@
       }
     },
     "packages/io-ts-bigint": {
-      "version": "0.0.0-semantically-released",
+      "version": "2.0.0",
       "license": "ISC",
       "devDependencies": {
         "@ericcrosson/eslint-config": "2.0.1",
@@ -13978,7 +13978,7 @@
       }
     },
     "packages/io-ts-numbers": {
-      "version": "0.0.0-semantically-released",
+      "version": "1.0.3",
       "license": "ISC",
       "devDependencies": {
         "@ericcrosson/eslint-config": "2.0.1",

--- a/packages/fast-check-bigint/package.json
+++ b/packages/fast-check-bigint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-check-bigint",
-  "version": "0.0.0-semantically-released",
+  "version": "1.0.0",
   "description": "fast-check arbitraries for narrowed bigint types",
   "keywords": [
     "fast-check",

--- a/packages/fast-check-numbers/package.json
+++ b/packages/fast-check-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-check-numbers",
-  "version": "0.0.0-semantically-released",
+  "version": "1.1.1",
   "description": "fast-check arbitraries for narrowed numeric types",
   "keywords": [
     "fast-check",

--- a/packages/io-ts-bigint/package.json
+++ b/packages/io-ts-bigint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts-bigint",
-  "version": "0.0.0-semantically-released",
+  "version": "2.0.0",
   "description": "io-ts library for bigints",
   "keywords": [
     "io-ts",

--- a/packages/io-ts-numbers/package.json
+++ b/packages/io-ts-numbers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-ts-numbers",
-  "version": "0.0.0-semantically-released",
+  "version": "1.0.3",
   "description": "io-ts library for numbers",
   "keywords": [
     "io-ts",


### PR DESCRIPTION
Turns out we can't use these placeholder version-numbers or `npm install`
complains about unresolvable peer dependencies. There is probably a
workaround but I have to time-box this effort today, so if there is an
issue with these out-of-date versions we will resolve it later.