### PR TITLE
fix: do not use codec in arbitrary definition

### DIFF
--- a/packages/fast-check-bigint/src/NegativeBigInt.ts
+++ b/packages/fast-check-bigint/src/NegativeBigInt.ts
@@ -10,4 +10,4 @@ import { NegativeBigInt } from 'io-ts-bigint'
  */
 export const NegativeBigIntArbitrary: fc.Arbitrary<NegativeBigInt> = fc
   .bigInt({ max: BigInt(-1) })
-  .filter(NegativeBigInt.is)
+  .filter((n): n is NegativeBigInt => typeof n === 'bigint' && n < BigInt(0))

--- a/packages/fast-check-bigint/src/NonNegativeBigInt.ts
+++ b/packages/fast-check-bigint/src/NonNegativeBigInt.ts
@@ -10,4 +10,6 @@ import { NonNegativeBigInt } from 'io-ts-bigint'
  */
 export const NonNegativeBigIntArbitrary: fc.Arbitrary<NonNegativeBigInt> = fc
   .bigInt({ min: BigInt(0) })
-  .filter(NonNegativeBigInt.is)
+  .filter(
+    (n): n is NonNegativeBigInt => typeof n === 'bigint' && BigInt(0) <= n,
+  )

--- a/packages/fast-check-bigint/src/NonPositiveBigInt.ts
+++ b/packages/fast-check-bigint/src/NonPositiveBigInt.ts
@@ -10,4 +10,6 @@ import { NonPositiveBigInt } from 'io-ts-bigint'
  */
 export const NonPositiveBigIntArbitrary: fc.Arbitrary<NonPositiveBigInt> = fc
   .bigInt({ max: BigInt(0) })
-  .filter(NonPositiveBigInt.is)
+  .filter(
+    (n): n is NonPositiveBigInt => typeof n === 'bigint' && n <= BigInt(0),
+  )

--- a/packages/fast-check-bigint/src/NonZeroBigInt.ts
+++ b/packages/fast-check-bigint/src/NonZeroBigInt.ts
@@ -10,4 +10,4 @@ import { NonZeroBigInt } from 'io-ts-bigint'
  */
 export const NonZeroBigIntArbitrary: fc.Arbitrary<NonZeroBigInt> = fc
   .bigInt()
-  .filter(NonZeroBigInt.is)
+  .filter((n): n is NonZeroBigInt => typeof n === 'bigint' && n !== BigInt(0))

--- a/packages/fast-check-bigint/src/PositiveBigInt.ts
+++ b/packages/fast-check-bigint/src/PositiveBigInt.ts
@@ -10,4 +10,4 @@ import { PositiveBigInt } from 'io-ts-bigint'
  */
 export const PositiveBigIntArbitrary: fc.Arbitrary<PositiveBigInt> = fc
   .bigInt({ min: BigInt(1) })
-  .filter(PositiveBigInt.is)
+  .filter((n): n is PositiveBigInt => typeof n === 'bigint' && BigInt(0) < n)

--- a/packages/fast-check-bigint/src/ZeroBigInt.ts
+++ b/packages/fast-check-bigint/src/ZeroBigInt.ts
@@ -10,4 +10,4 @@ import { ZeroBigInt } from 'io-ts-bigint'
  */
 export const ZeroBigIntArbitrary: fc.Arbitrary<ZeroBigInt> = fc
   .constant(BigInt(0))
-  .filter(ZeroBigInt.is)
+  .filter((n): n is ZeroBigInt => typeof n === 'bigint' && n === BigInt(0))

--- a/packages/fast-check-numbers/src/Int.ts
+++ b/packages/fast-check-numbers/src/Int.ts
@@ -8,4 +8,6 @@ import * as t from 'io-ts'
 /**
  * @since 1.1.0
  */
-export const IntArbitrary: fc.Arbitrary<t.Int> = fc.integer().filter(t.Int.is)
+export const IntArbitrary: fc.Arbitrary<t.Int> = fc
+  .integer()
+  .filter((n): n is t.Int => Number.isInteger(n))

--- a/packages/fast-check-numbers/src/Negative.ts
+++ b/packages/fast-check-numbers/src/Negative.ts
@@ -11,4 +11,4 @@ import { Negative } from 'io-ts-numbers'
 export const NegativeArbitrary: fc.Arbitrary<Negative> = fc
   .tuple(fc.float(), fc.integer())
   .map(([f, i]) => f * i)
-  .filter(Negative.is)
+  .filter((n): n is Negative => n < 0)

--- a/packages/fast-check-numbers/src/NegativeInt.ts
+++ b/packages/fast-check-numbers/src/NegativeInt.ts
@@ -11,4 +11,4 @@ import { Negative } from 'io-ts-numbers'
  */
 export const NegativeIntArbitrary: fc.Arbitrary<Negative & t.Int> = fc
   .integer({ max: -1 })
-  .filter((n): n is Negative & t.Int => Negative.is(n) && t.Int.is(n))
+  .filter((n): n is Negative & t.Int => n < 0 && Number.isInteger(n))

--- a/packages/fast-check-numbers/src/NonNegative.ts
+++ b/packages/fast-check-numbers/src/NonNegative.ts
@@ -11,4 +11,4 @@ import { NonNegative } from 'io-ts-numbers'
 export const NonNegativeArbitrary: fc.Arbitrary<NonNegative> = fc
   .tuple(fc.float(), fc.integer())
   .map(([f, i]) => f * i)
-  .filter(NonNegative.is)
+  .filter((n): n is NonNegative => 0 <= n)

--- a/packages/fast-check-numbers/src/NonNegativeInt.ts
+++ b/packages/fast-check-numbers/src/NonNegativeInt.ts
@@ -13,4 +13,4 @@ export const NonNegativeIntArbitrary: fc.Arbitrary<
   NonNegative & t.Int
 > = fc
   .integer({ min: 0 })
-  .filter((n): n is NonNegative & t.Int => NonNegative.is(n) && t.Int.is(n))
+  .filter((n): n is NonNegative & t.Int => 0 <= n && Number.isInteger(n))

--- a/packages/fast-check-numbers/src/NonPositive.ts
+++ b/packages/fast-check-numbers/src/NonPositive.ts
@@ -11,4 +11,4 @@ import { NonPositive } from 'io-ts-numbers'
 export const NonPositiveArbitrary: fc.Arbitrary<NonPositive> = fc
   .tuple(fc.float(), fc.integer())
   .map(([f, i]) => f * i)
-  .filter(NonPositive.is)
+  .filter((n): n is NonPositive => n <= 0)

--- a/packages/fast-check-numbers/src/NonPositiveInt.ts
+++ b/packages/fast-check-numbers/src/NonPositiveInt.ts
@@ -13,4 +13,4 @@ export const NonPositiveIntArbitrary: fc.Arbitrary<
   NonPositive & t.Int
 > = fc
   .integer({ max: 0 })
-  .filter((n): n is NonPositive & t.Int => NonPositive.is(n) && t.Int.is(n))
+  .filter((n): n is NonPositive & t.Int => n <= 0 && Number.isInteger(n))

--- a/packages/fast-check-numbers/src/NonZero.ts
+++ b/packages/fast-check-numbers/src/NonZero.ts
@@ -11,4 +11,4 @@ import { NonZero } from 'io-ts-numbers'
 export const NonZeroArbitrary: fc.Arbitrary<NonZero> = fc
   .tuple(fc.float(), fc.integer())
   .map(([f, i]) => f * i)
-  .filter(NonZero.is)
+  .filter((n): n is NonZero => n !== 0)

--- a/packages/fast-check-numbers/src/NonZeroInt.ts
+++ b/packages/fast-check-numbers/src/NonZeroInt.ts
@@ -13,4 +13,4 @@ export const NonZeroIntArbitrary: fc.Arbitrary<
   NonZero & t.Int
 > = fc
   .integer()
-  .filter((n): n is NonZero & t.Int => NonZero.is(n) && t.Int.is(n))
+  .filter((n): n is NonZero & t.Int => n !== 0 && Number.isInteger(n))

--- a/packages/fast-check-numbers/src/Positive.ts
+++ b/packages/fast-check-numbers/src/Positive.ts
@@ -11,4 +11,4 @@ import { Positive } from 'io-ts-numbers'
 export const PositiveArbitrary: fc.Arbitrary<Positive> = fc
   .tuple(fc.float(), fc.integer())
   .map(([f, i]) => f * i)
-  .filter(Positive.is)
+  .filter((n): n is Positive => 0 < n)

--- a/packages/fast-check-numbers/src/PositiveInt.ts
+++ b/packages/fast-check-numbers/src/PositiveInt.ts
@@ -11,4 +11,4 @@ import { Positive } from 'io-ts-numbers'
  */
 export const PositiveIntArbitrary: fc.Arbitrary<Positive & t.Int> = fc
   .integer({ min: 1 })
-  .filter((n): n is Positive & t.Int => Positive.is(n) && t.Int.is(n))
+  .filter((n): n is Positive & t.Int => 0 < n && Number.isInteger(n))

--- a/packages/fast-check-numbers/src/Zero.ts
+++ b/packages/fast-check-numbers/src/Zero.ts
@@ -10,4 +10,4 @@ import { Zero } from 'io-ts-numbers'
  */
 export const ZeroArbitrary: fc.Arbitrary<Zero> = fc
   .oneof(fc.constant(0), fc.constant(-0))
-  .filter(Zero.is)
+  .filter((n): n is Zero => n === 0)


### PR DESCRIPTION
Using the codec in the arbitrary definition is a tautology and thus bugs
in the codec definition would not be caught in the tests.